### PR TITLE
Make api_host to be configurable

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -134,16 +134,7 @@ In Icinga Web, navigate to Configuration > Modules, and select dependency plugin
 ### Launch Kickstart Page
 Finally, navigate to to the modules entry in Icinga Web 2 to automatically launch the kickstart page and finish the setup process by selecting created resource and entering in Icinga 2 API information. The icinga2 default API port is 5665. If you have misconfigured the settings and maybe getting an `Unexpected Error Encountered, Check Console` you may always call /dependency_plugin/module/kickstart again to correct the settings again.
 
+# Upgrade
 
-
-
-
-
-
-
-
-
-
-
-
-
+Apply all files ending with `-migration.sql` which are in `application/schema` in ascending
+order.

--- a/application/controllers/ModuleController.php
+++ b/application/controllers/ModuleController.php
@@ -238,9 +238,10 @@ class ModuleController extends Controller{
         if($data != null){
 
             $resource = $data[0]['value'];
-            $port = $data[1]['value'];
-            $username = $data[2]['value'];
-            $password = $data[3]['value'];
+            $host = $data[1]['value'];
+            $port = $data[2]['value'];
+            $username = $data[3]['value'];
+            $password = $data[4]['value'];
 
 
             try {
@@ -252,6 +253,7 @@ class ModuleController extends Controller{
                 'api_user' => $username, 
                 'api_password' => $password, 
                 'api_endpoint' => $port,
+                'api_host' => $host,
             ));
 
             $config = $this->config();
@@ -300,7 +302,7 @@ class ModuleController extends Controller{
                 die(json_encode(array('message' => $e->getMessage(), 'code' => '500')));
         }
 
-            $request_url = 'https://localhost:'. $vals[0]->api_endpoint . '/v1/objects/dependencies';
+            $request_url = 'https://' . $vals[0]->api_host . ':'. $vals[0]->api_endpoint . '/v1/objects/dependencies';
             $username = $vals[0]->api_user;
             $password = $vals[0]->api_password;
             $headers = array(
@@ -361,7 +363,7 @@ class ModuleController extends Controller{
                 die(json_encode(array('message' => $e->getMessage(), 'code' => "500")));
         }
 
-            $request_url = 'https://localhost:'. $vals[0]->api_endpoint . '/v1/objects/hosts';
+            $request_url = 'https://' . $vals[0]->api_host . ':'. $vals[0]->api_endpoint . '/v1/objects/hosts';
             $username = $vals[0]->api_user;
             $password = $vals[0]->api_password;
             $headers = array(

--- a/application/schema/01-migration.sql
+++ b/application/schema/01-migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plugin_settings ADD api_host TEXT DEFAULT 'localhost';

--- a/application/views/scripts/module/kickstart.phtml
+++ b/application/views/scripts/module/kickstart.phtml
@@ -25,6 +25,12 @@
                 <legend>API Login Information</legend>
                 <dl>
                     <!-- <div class="hint"></div> -->
+                    <dt id="host-label">
+                        <label for="host">Host</label>
+                    </dt>
+                    <dd id="host-element">
+                        <input type="text" name="host" id="host-field">
+                    </dd>
                     <dt id="port-label">
                         <label for="port">Port</label>
                     </dt>


### PR DESCRIPTION
Up until this commit, the icinga2 api endpoint (which is used for
gathering dependency information) was hardcoded to localhost.

Fixes issue #3 